### PR TITLE
🐛 FIX: muestra el background al cambiar los controles

### DIFF
--- a/scripts/gradient.js
+++ b/scripts/gradient.js
@@ -9,7 +9,7 @@ function newGradient(){
 
     let color_background = document.querySelector("#color-gradient")
 
-    color_background.style.background = `linear-gradient(90deg, rgb(${R0},${G0},${B0}),rgb(${R1},${G1},${B1}));`
+    color_background.style.background = `linear-gradient(90deg, rgb(${R0},${G0},${B0}),rgb(${R1},${G1},${B1}))`
 
  
 }


### PR DESCRIPTION
Resulta que el ; del final rompe por completo esto.
Lo peor de todo, cuando añadamos el texto debajo con el código necesario de CSS para poderlo copiar y pegar en nuestros codigos `.css` tendremos que volver a ponerlo, imagina que copias y pegas tu cogido resultante asi:

```
section{
background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%)
height: 100vh;
}
```

ese codigo no cogeria el height, porque carece de ; al final.
